### PR TITLE
Add Support for PhantomData

### DIFF
--- a/derive/tests/mod.rs
+++ b/derive/tests/mod.rs
@@ -32,6 +32,14 @@ struct Struct<A, B, C> {
 	pub c: C,
 }
 
+
+#[derive(Debug, PartialEq, Encode, Decode)]
+struct StructWithPhantom {
+	pub a: u32,
+	pub b: u64,
+	_c: ::std::marker::PhantomData<u8>,
+}
+
 type TestType = Struct<u32, u64, Vec<u8>>;
 
 impl <A, B, C> Struct<A, B, C> {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -281,6 +281,21 @@ impl<'a, T: ToOwned + ?Sized> Decode for ::std::borrow::Cow<'a, T> where
 }
 
 #[cfg(feature = "std")]
+impl<T> Encode for ::std::marker::PhantomData<T> {
+       fn encode_to<W: Output>(&self, _dest: &mut W) {
+       }
+}
+
+#[cfg(feature = "std")]
+impl<T> Decode for ::std::marker::PhantomData<T> {
+       fn decode<I: Input>(_input: &mut I) -> Option<Self> {
+               Some(::std::marker::PhantomData)
+       }
+}
+
+
+
+#[cfg(feature = "std")]
 impl Encode for String {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		self.as_bytes().encode_to(dest)


### PR DESCRIPTION
Allow us to derive Struct that contain `::std::marker::PhantomData`