### PR TITLE
Implements `encoded_as` and `compact`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ std = []
 
 [workspace]
 members = [
-	"derive"
+	"derive",
 ]

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -17,6 +17,7 @@ use syn::{
 	Data, Fields,
 	spanned::Spanned,
 };
+use utils;
 
 pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream {
 	let call_site = Span::call_site();
@@ -40,7 +41,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 
 			let recurse = data.variants.iter().enumerate().map(|(i, v)| {
 				let name = &v.ident;
-				let index = super::index(v, i);
+				let index = utils::index(v, i);
 
 				let create = create_instance(
 					call_site,

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -13,10 +13,7 @@
 // limitations under the License.
 
 use proc_macro2::{Span, TokenStream, Ident};
-use syn::{
-	Data, Fields,
-	spanned::Spanned,
-};
+use syn::{Data, Fields, Field, spanned::Spanned};
 use utils;
 
 pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream {
@@ -70,15 +67,43 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 	}
 }
 
-fn create_instance(call_site: Span, name: TokenStream, input: &TokenStream, fields: &Fields) -> TokenStream {
+fn create_decode_expr(field: &Field, input: &TokenStream) -> TokenStream {
+	let encoded_as = utils::get_encoded_as_type(field);
+	let compact = utils::get_enable_compact(field);
+
+	if encoded_as.is_some() && compact {
+		panic!("`encoded_as` and `compact` can not be used at the same time!");
+	}
+
+	if compact {
+		let field_type = &field.ty;
+		quote_spanned! { field.span() =>
+			 <Compact<#field_type> as _parity_codec::Decode>::decode(#input)?.into()
+		}
+	} else if let Some(encoded_as) = encoded_as {
+		quote_spanned! { field.span() =>
+			 <#encoded_as as _parity_codec::Decode>::decode(#input)?.into()
+		}
+	} else {
+		quote_spanned! { field.span() => _parity_codec::Decode::decode(#input)? }
+	}
+}
+
+fn create_instance(
+	call_site: Span,
+	name: TokenStream,
+	input: &TokenStream,
+	fields: &Fields
+) -> TokenStream {
 	match *fields {
 		Fields::Named(ref fields) => {
 			let recurse = fields.named.iter().map(|f| {
 				let name = &f.ident;
 				let field = quote_spanned!(call_site => #name);
+				let decode = create_decode_expr(f, input);
 
 				quote_spanned! { f.span() =>
-					#field: _parity_codec::Decode::decode(#input)?
+					#field: #decode
 				}
 			});
 
@@ -90,9 +115,7 @@ fn create_instance(call_site: Span, name: TokenStream, input: &TokenStream, fiel
 		},
 		Fields::Unnamed(ref fields) => {
 			let recurse = fields.unnamed.iter().map(|f| {
-				quote_spanned! { f.span() =>
-					_parity_codec::Decode::decode(#input)?
-				}
+				create_decode_expr(f, input)
 			});
 
 			quote_spanned! {call_site =>

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -39,7 +39,7 @@ fn encode_fields<F>(
 		let encode_as = super::get_encode_type(f);
 
 		if encode_as.is_some() {
-			let ts = quote!{ <Compact<u64>> };
+			let ts = quote!{ <<Foo as HasCompact>::Type> };
 			//let test = Ident::new(&encode_as.unwrap(), Span::call_site());
 
 			let x = quote_spanned! { f.span() => {

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -36,9 +36,18 @@ fn encode_fields<F>(
 {
 	let recurse = fields.iter().enumerate().map(|(i, f)| {
 		let field = field_name(i, &f.ident);
+		let encode_as = super::get_encode_type(f);
 
-		quote_spanned! { f.span() =>
-			#dest.push(#field);
+		if encode_as.is_some() {
+			quote_spanned! { f.span() => {
+					let r = #encode_as::from(#field).encode();
+					#dest.write(&r);
+				}
+			}
+		} else {
+			quote_spanned! { f.span() =>
+					#dest.push(#field);
+			}
 		}
 	});
 

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -41,6 +41,8 @@ fn encode_fields<F>(
 			panic!("`encoded_as` and `compact` can not be used at the same time!");
 		}
 
+		// Based on the seen attribute, we generate the code that encodes the field.
+		// We call `push` from the `Output` trait on `dest`.
 		if compact {
 			let field_type = &f.ty;
 			quote_spanned! { f.span() => { #dest.push(&Compact::<#field_type>::from(#field)); } }

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -16,6 +16,7 @@
 use core::str::from_utf8;
 #[cfg(feature = "std")]
 use std::str::from_utf8;
+use std::str::FromStr;
 
 use proc_macro2::{Span, TokenStream};
 use syn::{
@@ -37,18 +38,25 @@ fn encode_fields<F>(
 	let recurse = fields.iter().enumerate().map(|(i, f)| {
 		let field = field_name(i, &f.ident);
 		let encode_as = super::get_encode_type(f);
+		let compact = super::get_compact_type(f);
 
+		// if compact.is_some() {
+		// 	quote_spanned! { f.span() => {
+		// 		let x: Compact<Foo> = Compact::<Foo>::from(#field);
+		// 			#dest.push(&x);
+		// 		}
+		// 	}
+		// }
+		// else
 		if encode_as.is_some() {
-			let ts = quote!{ <<Foo as HasCompact>::Type> };
+			let ts = TokenStream::from_str(&encode_as.unwrap()).unwrap();
 			//let test = Ident::new(&encode_as.unwrap(), Span::call_site());
 
 			let x = quote_spanned! { f.span() => {
-					let r = #ts::from(#field).encode();
-					#dest.write(&r);
+					let lol= #ts::from(*#field);
+					#dest.push(&lol);
 				}
 			};
-
-			println!("Stuff: {}", x.to_string());
 
 			x
 		} else {

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(feature = "std"))]
-use core::str::from_utf8;
-#[cfg(feature = "std")]
 use std::str::from_utf8;
 
 use proc_macro2::{Span, TokenStream};

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -39,11 +39,11 @@ fn encode_fields<F>(
 		let encode_as = super::get_encode_type(f);
 
 		if encode_as.is_some() {
-			let ts = TokenStream::from_str(encode_as);
-			let test = Ident::new(&ts, Span::call_site());
+			let ts = quote!{ <Compact<u64>> };
+			//let test = Ident::new(&encode_as.unwrap(), Span::call_site());
 
 			let x = quote_spanned! { f.span() => {
-					let r = #test::from(#field).encode();
+					let r = #ts::from(#field).encode();
 					#dest.write(&r);
 				}
 			};

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #[cfg(not(feature = "std"))]
-use core::str::{from_utf8, FromStr};
+use core::str::from_utf8;
 #[cfg(feature = "std")]
-use std::str::{from_utf8, FromStr};
+use std::str::from_utf8;
 
 use proc_macro2::{Span, TokenStream};
 use syn::{
@@ -47,9 +47,7 @@ fn encode_fields<F>(
 		if compact {
 			let field_type = &f.ty;
 			quote_spanned! { f.span() => { #dest.push(&Compact::<#field_type>::from(#field)); } }
-		} else if encoded_as.is_some() {
-			let encoded_as = TokenStream::from_str(&encoded_as.unwrap())
-				.expect("`encoded_as` should be a valid rust type!");
+		} else if let Some(encoded_as) = encoded_as {
 			quote_spanned! { f.span() => { #dest.push(&#encoded_as::from(*#field)); } }
 		} else {
 			quote_spanned! { f.span() =>

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -39,11 +39,18 @@ fn encode_fields<F>(
 		let encode_as = super::get_encode_type(f);
 
 		if encode_as.is_some() {
-			quote_spanned! { f.span() => {
-					let r = #encode_as::from(#field).encode();
+			let ts = TokenStream::from_str(encode_as);
+			let test = Ident::new(&ts, Span::call_site());
+
+			let x = quote_spanned! { f.span() => {
+					let r = #test::from(#field).encode();
 					#dest.write(&r);
 				}
-			}
+			};
+
+			println!("Stuff: {}", x.to_string());
+
+			x
 		} else {
 			quote_spanned! { f.span() =>
 					#dest.push(#field);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -166,14 +166,14 @@ fn get_encode_type(field_entry: &syn::Field) -> Option<String> {
 	let encoder_type = field_entry.attrs.iter().filter_map(|attr| {
 		let pair = attr.path.segments.first()?;
 		let seg = pair.value();
-
+		println!("Seg Ident: {}", seg.ident);
 		if seg.ident == Ident::new("codec", seg.ident.span()) {
 			assert_eq!(attr.path.segments.len(), 1);
 
 			let meta = attr.interpret_meta();
 			if let Some(syn::Meta::List(ref l)) = meta {
 				if let syn::NestedMeta::Meta(syn::Meta::NameValue(ref nv)) = l.nested.last().unwrap().value() {
-					assert_eq!(nv.ident, Ident::new("encode_as", nv.ident.span()));
+					assert_eq!(nv.ident, Ident::new("encoded_as", nv.ident.span()));
 					if let syn::Lit::Str(ref s) = nv.lit {
 						let encoding: String = s.value();
 						return Some(encoding)

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,13 +14,6 @@
 
 //! Derives serialization and deserialization codec for complex structs for simple marshalling.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
-
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
 extern crate proc_macro;
 extern crate proc_macro2;
 
@@ -33,9 +26,6 @@ extern crate quote;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::{DeriveInput, Generics, GenericParam, Ident};
-
-#[cfg(not(feature = "std"))]
-use alloc::string::ToString;
 
 mod decode;
 mod encode;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -62,6 +62,8 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 		}
 	};
 
+	println!("imp_block: {}", impl_block);
+
 	let mut new_name = "_IMPL_ENCODE_FOR_".to_string();
 	new_name.push_str(name.to_string().trim_left_matches("r#"));
 	let dummy_const = Ident::new(&new_name, Span::call_site());

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -173,9 +173,11 @@ fn get_encode_type(field_entry: &syn::Field) -> Option<String> {
 			let meta = attr.interpret_meta();
 			if let Some(syn::Meta::List(ref l)) = meta {
 				if let syn::NestedMeta::Meta(syn::Meta::NameValue(ref nv)) = l.nested.last().unwrap().value() {
+					println!("NV Ident: {}", nv.ident);
 					assert_eq!(nv.ident, Ident::new("encoded_as", nv.ident.span()));
 					if let syn::Lit::Str(ref s) = nv.lit {
 						let encoding: String = s.value();
+						println!("Encoding: {}", encoding);
 						return Some(encoding)
 					}
 					panic!("Invalid syntax for `codec` attribute: Expected string literal.")

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -14,6 +14,7 @@
 
 use syn::{Meta, NestedMeta, Lit, Attribute, Variant, Field};
 use proc_macro2::TokenStream;
+use std::str::FromStr;
 
 fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 	F: FnMut(&NestedMeta) -> Option<R> + Clone,
@@ -57,13 +58,16 @@ pub fn index(v: &Variant, i: usize) -> TokenStream {
 		)
 }
 
-pub fn get_encoded_as_type(field_entry: &Field) -> Option<String> {
+pub fn get_encoded_as_type(field_entry: &Field) -> Option<TokenStream> {
 	// look for an encoded_as in attributes
 	find_meta_item(field_entry.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
 			if nv.ident == "encoded_as"{
 				if let Lit::Str(ref s) = nv.lit {
-					return Some(s.value())
+					return Some(
+						TokenStream::from_str(&s.value())
+							.expect("`encoded_as` should be a valid rust type!")
+					);
 				}
 			}
 		}

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,0 +1,86 @@
+// Copyright 2018 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use syn::{Meta, NestedMeta, Lit, Attribute, Variant, Field};
+use proc_macro2::TokenStream;
+
+fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
+	F: FnMut(&NestedMeta) -> Option<R> + Clone,
+	I: Iterator<Item=&'a Attribute>
+{
+	itr.filter_map(|attr| {
+		let pair = attr.path.segments.first()?;
+		let seg = pair.value();
+		if seg.ident == "codec" {
+			let meta = attr.interpret_meta();
+			if let Some(Meta::List(ref meta_list)) = meta {
+				return meta_list.nested.iter().filter_map(pred.clone()).next();
+			}
+		}
+
+		None
+	}).next()
+}
+
+pub fn index(v: &Variant, i: usize) -> TokenStream {
+	// look for an index in attributes
+	let index = find_meta_item(v.attrs.iter(), |meta| {
+		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
+			if nv.ident == "index" {
+				if let Lit::Str(ref s) = nv.lit {
+					let byte: u8 = s.value().parse().expect("Numeric index expected.");
+					return Some(byte)
+				}
+			}
+		}
+
+		None
+	});
+
+	// then fallback to discriminant or just index
+	index.map(|i| quote! { #i })
+		.unwrap_or_else(|| v.discriminant
+			.as_ref()
+			.map(|&(_, ref expr)| quote! { #expr })
+			.unwrap_or_else(|| quote! { #i })
+		)
+}
+
+pub fn get_encoded_as_type(field_entry: &Field) -> Option<String> {
+	// look for an encoded_as in attributes
+	find_meta_item(field_entry.attrs.iter(), |meta| {
+		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
+			if nv.ident == "encoded_as"{
+				if let Lit::Str(ref s) = nv.lit {
+					return Some(s.value())
+				}
+			}
+		}
+
+		None
+	})
+}
+
+pub fn get_enable_compact(field_entry: &Field) -> bool {
+	// look for `encode(compact)` in the attributes
+	find_meta_item(field_entry.attrs.iter(), |meta| {
+		if let NestedMeta::Meta(Meta::Word(ref word)) = meta {
+			if word == "compact" {
+				return Some(());
+			}
+		}
+
+		None
+	}).is_some()
+}

--- a/derive/tests/mod.rs
+++ b/derive/tests/mod.rs
@@ -66,18 +66,20 @@ enum EnumWithDiscriminant {
 	C = 255,
 }
 
-trait HasCompact {
-  type Type: Encode + Decode;
+trait HasCompact: Copy {
+	type Type: Encode + Decode + From<Self>;
 }
 
-impl HasCompact for u64 {
-  type Type = Compact<u64>;
+impl<T> HasCompact for T where T: Encode + Decode + Copy, Compact<T>: Encode + Decode + From<T> {
+	type Type = Compact<T>;
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Something<Foo: HasCompact> {
-  #[codec(encoded_as = "<Foo as HasCompact>::Type")]
-  bar: Foo,
+	#[codec(encoded_as = "<Foo as HasCompact>::Type")]
+	// #[codec(compact)]
+	bar: Foo,
+	// test: u64,
 }
 
 #[test]

--- a/derive/tests/mod.rs
+++ b/derive/tests/mod.rs
@@ -172,25 +172,14 @@ fn should_work_for_indexed() {
 
 #[test]
 fn compact_64_encoding_works() {
-	let n = 64;
-	let v: Something<u64> = Something {bar: n};
-	let encoded = Compact(n as u64).encode();
-
-	println!("Compact: {}", v.bar);
-
-	assert_eq!(encoded, v.bar);
-	/*
-
 	let tests = [
 		(0u64, 1usize), (63, 1), (64, 2), (16383, 2),
 		(16384, 4), (1073741823, 4),
 		(1073741824, 9), (u32::max_value() as u64, 9), (u64::max_value(), 9),
 	];
-
 	for &(n, l) in &tests {
-		let encoded = Compact(n as u64).encode();
+		let encoded = Something { bar: n }.encode();
 		assert_eq!(encoded.len(), l);
 		assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
 	}
-	*/
 }

--- a/derive/tests/mod.rs
+++ b/derive/tests/mod.rs
@@ -178,7 +178,7 @@ fn encoded_as_with_has_compact_works() {
 	for &(n, l) in &tests {
 		let encoded = TestHasCompact { bar: n }.encode();
 		assert_eq!(encoded.len(), l);
-		assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
+		assert_eq!(<TestHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar, n);
 	}
 }
 
@@ -192,6 +192,6 @@ fn compact_meta_attribute_works() {
 	for &(n, l) in &tests {
 		let encoded = TestCompactAttribute { bar: n }.encode();
 		assert_eq!(encoded.len(), l);
-		assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
+		assert_eq!(TestCompactAttribute::decode(&mut &encoded[..]).unwrap().bar, n);
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -137,25 +137,32 @@ pub struct Compact<T>(pub T);
 impl<T> From<T> for Compact<T> {
 	fn from(x: T) -> Compact<T> { Compact(x) }
 }
+
 impl<'a, T: Copy> From<&'a T> for Compact<T> {
 	fn from(x: &'a T) -> Compact<T> { Compact(*x) }
 }
-impl From<Compact<u8>> for u8 {
-	fn from(x: Compact<u8>) -> u8 { x.0 }
+
+macro_rules! impl_from_compact {
+	( $( $ty:ty ),* ) => {
+		$(
+			impl From<Compact<$ty>> for $ty {
+				fn from(x: Compact<$ty>) -> $ty { x.0 }
+			}
+		)*
+	}
 }
-impl From<Compact<u16>> for u16 {
-	fn from(x: Compact<u16>) -> u16 { x.0 }
-}
-impl From<Compact<u32>> for u32 {
-	fn from(x: Compact<u32>) -> u32 { x.0 }
-}
+
+impl_from_compact! { u8, u16, u32, u64, u128 }
 
 /// Trait that tells you if a given type can be encoded/decoded as `Compact<T>`.
 pub trait HasCompact: Copy {
-	type Type: Encode + Decode + From<Self>;
+	type Type: Encode + Decode + From<Self> + Into<Self>;
 }
 
-impl<T> HasCompact for T where T: Encode + Decode + Copy, Compact<T>: Encode + Decode + From<T> {
+impl<T> HasCompact for T where
+	T: Encode + Decode + Copy,
+	Compact<T>: Encode + Decode + From<T> + Into<Self>
+{
 	type Type = Compact<T>;
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -137,6 +137,9 @@ pub struct Compact<T>(pub T);
 impl<T> From<T> for Compact<T> {
 	fn from(x: T) -> Compact<T> { Compact(x) }
 }
+impl<'a, T: Copy> From<&'a T> for Compact<T> {
+	fn from(x: &'a T) -> Compact<T> { Compact(*x) }
+}
 impl From<Compact<u8>> for u8 {
 	fn from(x: Compact<u8>) -> u8 { x.0 }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -150,6 +150,15 @@ impl From<Compact<u32>> for u32 {
 	fn from(x: Compact<u32>) -> u32 { x.0 }
 }
 
+/// Trait that tells you if a given type can be encoded/decoded as `Compact<T>`.
+pub trait HasCompact: Copy {
+	type Type: Encode + Decode + From<Self>;
+}
+
+impl<T> HasCompact for T where T: Encode + Decode + Copy, Compact<T>: Encode + Decode + From<T> {
+	type Type = Compact<T>;
+}
+
 // compact encoding:
 // 0b00 00 00 00 / 00 00 00 00 / 00 00 00 00 / 00 00 00 00
 //   xx xx xx 00															(0 ... 2**6 - 1)		(u8)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,6 @@ mod codec;
 mod joiner;
 mod keyedvec;
 
-pub use self::codec::{Input, Output, Encode, Decode, Codec, Compact};
+pub use self::codec::{Input, Output, Encode, Decode, Codec, Compact, HasCompact};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/879

cc: @shawntabrizi 