### PR TITLE
Feature/btree map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,14 +24,14 @@ name = "parity-codec-derive"
 version = "2.1.0"
 dependencies = [
  "parity-codec 2.1.5",
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -39,10 +39,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -55,8 +55,8 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -68,8 +68,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -897,6 +897,30 @@ mod tests {
 	}
 
 	#[test]
+	fn btree_map_works() {
+		let mut m: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+		m.insert(1, b"qwe".to_vec());
+		m.insert(2, b"qweasd".to_vec());
+		let encoded = m.encode();
+
+		assert_eq!(m, Decode::decode(&mut &encoded[..]).unwrap());
+
+		let mut m: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
+		m.insert(b"123".to_vec(), b"qwe".to_vec());
+		m.insert(b"1234".to_vec(), b"qweasd".to_vec());
+		let encoded = m.encode();
+
+		assert_eq!(m, Decode::decode(&mut &encoded[..]).unwrap());
+
+		let mut m: BTreeMap<Vec<u32>, Vec<u8>> = BTreeMap::new();
+		m.insert(vec![1, 2, 3], b"qwe".to_vec());
+		m.insert(vec![1, 2], b"qweasd".to_vec());
+		let encoded = m.encode();
+
+		assert_eq!(m, Decode::decode(&mut &encoded[..]).unwrap());
+	}
+
+	#[test]
 	fn encode_borrowed_tuple() {
 		let x = vec![1u8, 2, 3, 4];
 		let y = 128i64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate arrayvec;
 pub mod alloc {
 	pub use std::boxed;
 	pub use std::vec;
+	pub use std::collections;
 }
 
 mod codec;


### PR DESCRIPTION
provide btree_map encode/decode for parity-codec, under std/wasm 
how to do:
btree_map<K, V> => Vec<(K, V)>
just use tuple vec method to encode/decode
have provided test case for encode/decode