### PR TITLE
Add no_std impl for some types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,19 @@ default = ["std"]
 derive = ["parity-codec-derive"]
 std = ["serde"]
 
+# WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
+#
+# Provides implementations for more data structures than just Vec and Box.
+# Concretely it will provides parity-codec implementations for many types
+# that can be found in std and/or alloc (nightly).
+#
+# This feature was mainly introduced after it became clear that pDSL requires
+# it for the sake of usability of its users.
+#
+# * For rational about this please visit:
+# https://github.com/paritytech/parity-codec/pull/27#issuecomment-453031914
+full = []
+
 [workspace]
 members = [
 	"derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ std = ["serde"]
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #
 # Provides implementations for more data structures than just Vec and Box.
-# Concretely it will provides parity-codec implementations for many types
+# Concretely it will provide parity-codec implementations for many types
 # that can be found in std and/or alloc (nightly).
 #
 # This feature was mainly introduced after it became clear that pDSL requires

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,8 @@ parity-codec-derive = { version = "2.0", default-features = false, optional = tr
 
 [features]
 default = ["std"]
-std = [
-	"serde"
-]
 derive = ["parity-codec-derive"]
+std = ["serde"]
 
 [workspace]
 members = [

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -54,7 +54,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 	};
 
 	let mut new_name = "_IMPL_ENCODE_FOR_".to_string();
-	new_name.push_str(name.to_string().trim_left_matches("r#"));
+	new_name.push_str(name.to_string().trim_start_matches("r#"));
 	let dummy_const = Ident::new(&new_name, Span::call_site());
 
 	let generated = quote! {
@@ -91,7 +91,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 	};
 
 	let mut new_name = "_IMPL_DECODE_FOR_".to_string();
-	new_name.push_str(name.to_string().trim_left_matches("r#"));
+	new_name.push_str(name.to_string().trim_start_matches("r#"));
 	let dummy_const = Ident::new(&new_name, Span::call_site());
 
 	let generated = quote! {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -167,9 +167,8 @@ impl<'a, T> From<&'a T> for CompactRef<'a, T> {
 	fn from(x: &'a T) -> Self { CompactRef(x) }
 }
 
-#[cfg(feature = "std")]
-impl<T> ::std::fmt::Debug for Compact<T> where T: ::std::fmt::Debug {
-	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl<T> ::core::fmt::Debug for Compact<T> where T: ::core::fmt::Debug {
+	fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 		self.0.fmt(f)
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -471,9 +471,8 @@ impl<T: Decode, E: Decode> Decode for Result<T, E> {
 #[derive(Eq, PartialEq, Clone, Copy)]
 pub struct OptionBool(pub Option<bool>);
 
-#[cfg(feature = "std")]
-impl ::std::fmt::Debug for OptionBool {
-	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl ::core::fmt::Debug for OptionBool {
+	fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
 		self.0.fmt(f)
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,7 @@
 use alloc::vec::Vec;
 use alloc::boxed::Box;
 use alloc::string::String;
-use alloc::borrow::Cow;
+use alloc::borrow::{Cow, ToOwned};
 
 use core::{mem, slice};
 use arrayvec::ArrayVec;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -168,16 +168,6 @@ impl<'a, T> From<&'a T> for CompactRef<'a, T> {
 }
 
 #[cfg(feature = "std")]
-pub trait MaybeDebugSerde: ::std::fmt::Debug + ::serde::Serialize + for<'a> ::serde::Deserialize<'a> {}
-#[cfg(feature = "std")]
-impl<T> MaybeDebugSerde for T where T: ::std::fmt::Debug + ::serde::Serialize + for<'a> ::serde::Deserialize<'a> {}
-
-#[cfg(not(feature = "std"))]
-pub trait MaybeDebugSerde {}
-#[cfg(not(feature = "std"))]
-impl<T> MaybeDebugSerde for T {}
-
-#[cfg(feature = "std")]
 impl<T> ::std::fmt::Debug for Compact<T> where T: ::std::fmt::Debug {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
 		self.0.fmt(f)
@@ -197,6 +187,16 @@ impl<'de, T> ::serde::Deserialize<'de> for Compact<T> where T: ::serde::Deserial
 		T::deserialize(deserializer).map(Compact)
 	}
 }
+
+#[cfg(feature = "std")]
+pub trait MaybeDebugSerde: ::core::fmt::Debug + ::serde::Serialize + for<'a> ::serde::Deserialize<'a> {}
+#[cfg(feature = "std")]
+impl<T> MaybeDebugSerde for T where T: ::core::fmt::Debug + ::serde::Serialize + for<'a> ::serde::Deserialize<'a> {}
+
+#[cfg(not(feature = "std"))]
+pub trait MaybeDebugSerde {}
+#[cfg(not(feature = "std"))]
+impl<T> MaybeDebugSerde for T {}
 
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -984,6 +984,14 @@ mod tests {
 	}
 
 	#[test]
+	fn string_encoded_as_expected() {
+		let value = String::from("Hello, World!");
+		let encoded = value.encode();
+		assert_eq!(hexify(&encoded), "34 48 65 6c 6c 6f 2c 20 57 6f 72 6c 64 21");
+		assert_eq!(<String>::decode(&mut &encoded[..]).unwrap(), value);
+	}
+
+	#[test]
 	fn vec_of_u8_encoded_as_expected() {
 		let value = vec![0u8, 1, 1, 2, 3, 5, 8, 13, 21, 34];
 		let encoded = value.encode();

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -16,8 +16,12 @@
 
 use alloc::vec::Vec;
 use alloc::boxed::Box;
-use alloc::string::String;
-use alloc::borrow::{Cow, ToOwned};
+
+#[cfg(any(feature = "std", feature = "full"))]
+use alloc::{
+	string::String,
+	borrow::{Cow, ToOwned},
+};
 
 use core::{mem, slice};
 use arrayvec::ArrayVec;
@@ -591,6 +595,7 @@ impl<'a> Encode for &'a str {
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl<'a, T: ToOwned + ?Sized + 'a> Encode for Cow<'a, T> where
 	&'a T: Encode,
 	<T as ToOwned>::Owned: Encode
@@ -603,6 +608,7 @@ impl<'a, T: ToOwned + ?Sized + 'a> Encode for Cow<'a, T> where
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl<'a, T: ToOwned + ?Sized> Decode for Cow<'a, T> where
 	<T as ToOwned>::Owned: Decode
 {
@@ -611,23 +617,27 @@ impl<'a, T: ToOwned + ?Sized> Decode for Cow<'a, T> where
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl<T> Encode for PhantomData<T> {
 	fn encode_to<W: Output>(&self, _dest: &mut W) {
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl<T> Decode for PhantomData<T> {
 	fn decode<I: Input>(_input: &mut I) -> Option<Self> {
 		Some(PhantomData)
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl Encode for String {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		self.as_bytes().encode_to(dest)
 	}
 }
 
+#[cfg(any(feature = "std", feature = "full"))]
 impl Decode for String {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		Some(Self::from_utf8_lossy(&Vec::decode(input)?).into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,10 @@ pub use parity_codec_derive::*;
 
 #[cfg(feature = "std")]
 pub mod alloc {
-	pub use std::boxed;
-	pub use std::vec;
+	pub use ::std::boxed;
+	pub use ::std::vec;
+	pub use ::std::string;
+	pub use ::std::borrow;
 }
 
 mod codec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,13 @@ pub mod alloc {
 	pub use ::std::vec;
 	pub use ::std::string;
 	pub use ::std::borrow;
+
+	#[cfg(feature = "full")]
+	mod full {
+		pub use ::std::borrow;
+	}
+	#[cfg(feature = "full")]
+	pub use self::full::*;
 }
 
 mod codec;


### PR DESCRIPTION
Adds `no_std` impls for `Encode` and `Decode` for:
- `alloc::string::String`
- `alloc::borrow::Cow`
- `core::marker::PhantomData`

Also adds `Debug` impl in `no_std` for
- `Compact<T>`
- `OptionBool`
