### PR TITLE
Add repository and categories fields to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ description = "Lightweight, efficient, binary serialization and deserialization 
 version = "2.1.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
+repository = "https://github.com/paritytech/parity-codec"
+categories = ["encoding"]
 
 [dependencies]
 arrayvec = { version = "0.4", default-features = false }


### PR DESCRIPTION
Adds `repository` and `categories` field to `Cargo.toml`.
This is just a very minor fix but it bugged me since I couldn't easily go from crates.io to the repository.