### PR TITLE
Resolve issue + extend Compact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -62,6 +63,16 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ arrayvec = { version = "0.4", default-features = false }
 serde = { version = "1.0", optional = true }
 parity-codec-derive = { version = "2.0", default-features = false, optional = true }
 
+[dev-dependencies]
+serde_derive = { version = "1.0" }
+
 [features]
 default = ["std"]
 std = [

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -54,7 +54,7 @@ fn encode_fields<F>(
 				f.span() => {
 					#dest.push(
 						&<#encoded_as as
-							_parity_codec::EncodeAsRef<#field_type>>::RefType::from(&#field)
+							_parity_codec::EncodeAsRef<#field_type>>::RefType::from(#field)
 					);
 				}
 			}

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -54,7 +54,7 @@ fn encode_fields<F>(
 				f.span() => {
 					#dest.push(
 						&<#encoded_as as
-							_parity_codec::EncodeAsRef<#field_type>>::RefType::from(#field)
+							_parity_codec::EncodeAsRef<#field_type>>::RefType::from(&#field)
 					);
 				}
 			}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -144,7 +144,7 @@ impl<'a, T: Copy> From<&'a T> for Compact<T> {
 }
 
 /// Allow foreign structs to be wrap in Compact
-pub trait CompactAs {
+pub trait CompactAs: From<Compact<Self>> {
 	type As;
 	fn encode_as(&self) -> &Self::As;
 	fn decode_from(Self::As) -> Self;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -197,7 +197,7 @@ impl<'de, T> ::serde::Deserialize<'de> for Compact<T> where T: ::serde::Deserial
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {
 	/// The compact type; this can be
-	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + Into<Self> + Clone +
+	type Type: for<'a> EncodeAsRef<'a, Self> + Encode + Decode + From<Self> + Into<Self> + Clone +
 		PartialEq + Eq + MaybeDebugSerde;
 }
 
@@ -212,7 +212,7 @@ impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encod
 }
 
 impl<T: 'static> HasCompact for T where
-	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + Into<Self> + Clone +
+	Compact<T>: for<'a> EncodeAsRef<'a, T> + Encode + Decode + From<Self> + Into<Self> + Clone +
 		PartialEq + Eq + MaybeDebugSerde,
 {
 	type Type = Compact<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@ extern crate arrayvec;
 #[macro_use]
 extern crate parity_codec_derive;
 
+#[cfg(all(feature = "std", test))]
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(feature = "parity-codec-derive")]
 #[doc(hidden)]
 pub use parity_codec_derive::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,6 @@ mod codec;
 mod joiner;
 mod keyedvec;
 
-pub use self::codec::{Input, Output, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef};
+pub use self::codec::{Input, Output, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;


### PR DESCRIPTION
Resolve issue: 
macro modification, and adding of trait requirements are to make it compatible with substrate as it is now
* Encode might not be mandatory by modifying decl_module macros when it derive Encode for Call enum and some code
* From could be implemented using a trick (encode as ref and then decode)

Extend compact:
related to https://github.com/paritytech/substrate/issues/1405
to allow Permill to be written as Compact<Permill> we provide a trait to implement
then on substrate we will have do
```rust
impl codec::CompactAs for Permill {
       type As = u32;
       fn encode_as(&self) -> &u32 {
               &self.0
       }
       fn decode_from(x: u32) -> Permill {
               Permill(x)
       }
}

impl From<codec::Compact<Permill>> for Permill {
       fn from(x: codec::Compact<Permill>) -> Permill {
               x.0
       }
}
```

or we could provide some macro to help but seems OK