### PR TITLE
generalize #[codec(compact)]

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -78,7 +78,7 @@ fn create_decode_expr(field: &Field, input: &TokenStream) -> TokenStream {
 	if compact {
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
-			 <_parity_codec::Compact<#field_type> as _parity_codec::Decode>::decode(#input)?.into()
+			 <<#field_type as _parity_codec::HasCompact>::Type as _parity_codec::Decode>::decode(#input)?.into()
 		}
 	} else if let Some(encoded_as) = encoded_as {
 		quote_spanned! { field.span() =>

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -46,7 +46,12 @@ fn encode_fields<F>(
 		if compact {
 			let field_type = &f.ty;
 			quote_spanned! {
-				f.span() => { #dest.push(&_parity_codec::Compact::<#field_type>::from(#field)); }
+				f.span() => {
+					#dest.push(
+						&<<#field_type as _parity_codec::HasCompact>::Type as
+							_parity_codec::EncodeAsRef<#field_type>>::RefType::from(#field)
+					);
+				}
 			}
 		} else if let Some(encoded_as) = encoded_as {
 			let field_type = &f.ty;


### PR DESCRIPTION
By using HasCompact trait we can generalize the code generation to derive compact.

Thus this allow us to write
```rust
struct TestCompactHasCompact<T: HasCompact> {
	#[codec(compact)]	
        // instead of #[codec(encoded_as = "<T as HasCompact>::Type")]
	bar: T,
}
```

this has also been tested with substrate test --all