### PR TITLE
delete Encode requirement

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -242,7 +242,7 @@ impl<T> MaybeDebugSerde for T {}
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {
 	/// The compact type; this can be
-	type Type: for<'a> EncodeAsRef<'a, Self> + Encode + Decode + From<Self> + Into<Self> + Clone +
+	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self> + Clone +
 		PartialEq + Eq + MaybeDebugSerde;
 }
 
@@ -257,7 +257,7 @@ impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encod
 }
 
 impl<T: 'static> HasCompact for T where
-	Compact<T>: for<'a> EncodeAsRef<'a, T> + Encode + Decode + From<Self> + Into<Self> + Clone +
+	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self> + Clone +
 		PartialEq + Eq + MaybeDebugSerde,
 {
 	type Type = Compact<T>;


### PR DESCRIPTION
due to https://github.com/paritytech/substrate/pull/1499 we don't use <... as HasCompact>::Type in arguments.

Thus this actually make this modification ok for substrate except one line will have to use EncodeAsRef trait explicitly but it is very fine.

And then we can drop the Copy requirement on srml-staking
```rust
-pub struct ValidatorPrefs<Balance: HasCompact + Copy> { // TODO: @bkchr shouldn't need this Copy but derive(Encode) breaks otherwise
+pub struct ValidatorPrefs<Balance: HasCompact> {
```