### PR TITLE
Trait bounds for associated types

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -127,9 +127,7 @@ fn add_trait_bounds(generics: &mut Generics, data: &syn::Data, bound: syn::Path)
 	if !types.is_empty() {
 		let where_clause = generics.make_where_clause();
 
-		for ty in types {
-			where_clause.predicates.push(parse_quote!(#ty : #bound));
-		}
+		types.into_inter().for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #bound)));
 	}
 
 	Ok(())
@@ -145,7 +143,7 @@ fn collect_types(data: &syn::Data) -> Result<Vec<syn::Type>, syn::Error> {
 				fields.iter().map(|f| f.ty.clone()).collect()
 			},
 
-			Fields::Unit => { vec![] },
+			Fields::Unit => { Vec::new() },
 		},
 
 		Data::Enum(ref data) => data.variants.iter().flat_map(|variant| {
@@ -155,7 +153,7 @@ fn collect_types(data: &syn::Data) -> Result<Vec<syn::Type>, syn::Error> {
 					fields.iter().map(|f| f.ty.clone()).collect()
 				},
 
-				Fields::Unit => { vec![] },
+				Fields::Unit => { Vec::new() },
 			}
 		}).collect(),
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -127,7 +127,7 @@ fn add_trait_bounds(generics: &mut Generics, data: &syn::Data, bound: syn::Path)
 	if !types.is_empty() {
 		let where_clause = generics.make_where_clause();
 
-		types.into_inter().for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #bound)));
+		types.into_iter().for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #bound)));
 	}
 
 	Ok(())

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -271,19 +271,21 @@ fn enum_compact_meta_attribute_works() {
 #[test]
 fn associated_type_bounds() {
 	trait Trait {
-		type AssociatedType;
+		type EncodableType;
+		type NonEncodableType;
 	}
 
 	#[derive(Encode, Decode, Debug, PartialEq)]
 	struct Struct<T: Trait, Type> {
-		field: (Vec<T::AssociatedType>, Type),
+		field: (Vec<T::EncodableType>, Type),
 	}
 
 	#[derive(Debug, PartialEq)]
 	struct TraitImplementor;
 
 	impl Trait for TraitImplementor {
-		type AssociatedType = u32;
+		type EncodableType = u32;
+		type NonEncodableType = std::marker::PhantomData<Self>;
 	}
 
 	let value: Struct<TraitImplementor, u64> = Struct { field: (vec![1, 2, 3], 42) };

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -267,3 +267,27 @@ fn enum_compact_meta_attribute_works() {
 		}
 	}
 }
+
+#[test]
+fn associated_type_bounds() {
+	trait Trait {
+		type AssociatedType;
+	}
+
+	#[derive(Encode, Decode, Debug, PartialEq)]
+	struct Struct<T: Trait, Type> {
+		field: (Vec<T::AssociatedType>, Type),
+	}
+
+	#[derive(Debug, PartialEq)]
+	struct TraitImplementor;
+
+	impl Trait for TraitImplementor {
+		type AssociatedType = u32;
+	}
+
+	let value: Struct<TraitImplementor, u64> = Struct { field: (vec![1, 2, 3], 42) };
+	let encoded = value.encode();
+	let decoded: Struct<TraitImplementor, u64> = Struct::decode(&mut &encoded[..]).unwrap();
+	assert_eq!(value, decoded);
+}


### PR DESCRIPTION
### The problem

Previously custom derive for `Encode` and `Decode` traits used straightforward approach to generic types: it just added `: (En|De)code` bound to every declared type parameter it could find in the type definition.

So, for a struct like:
```rust
#[derive(Encode, Decode)]
struct Struct<T> {
	field: T
}
```

Custom derive would generate impls like this:
```rust
impl<T> Encode for Struct<T> where T: Encode { ... }
```

In most cases, this works just fine. However, in others, you may want to specify type parameter that is not expected to be encodable at all. Instead, it's used to pass several types at once. This pattern is prevalent in Substrate and SRML where we usually pass `T: Trait` here and there and downstream types use this `T` to specialize their structures with associated types. Otherwise, it would be impractical to pass dozens of configuration types instead of a single `T`.

For example, in [UTXO prototype](https://github.com/paritytech/substrate-node-template/pull/17) I'd like to use the following enum:

```rust
#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
#[derive(Clone, Encode, Decode, Hash)]
pub enum LockStatus<T: Trait>
{
	Locked,
	LockedUntil(T::BlockNumber),
}
```

and define the storage as:
```rust
decl_storage! {
	trait Store for Module<T: Trait> as Utxo {
		// ...
		LockedOutputs: map H256 => Option<LockStatus<T>>;
	}
}
```
Note that `LockStatus` struct does not expect the whole `T` to be encodable or decodable, it just needs that `T` to extract `T::BlockNumber` type. Obviously, previous implementation of custom derive didn't allowed me to do that since it would blindly create the impl with incorrect trait bound:  
```rust 
impl<T> Encode for LockStatus<T> where T: Trait, T: Encode { ... }
```

### The solution

This PR tries to address the issue by bounding actual types that are used, not the type parameters. When doing this, it exploits two facts:
- Rust allows trivial or redundant trait bounds
- Rust has a powerful type system and inference rules

The first fact allows us to write bounds several times without any warning or compilation error. For example, if we have a struct that declares two fields using the same associated type:
```rust
#[derive(Encode, Decode)]
struct Struct<T: Trait> {
	field1: T::AssociatedType,
	field2: T::AssociatedType,
}
```

upon impl generation, we would add `T::AssociatedType: Encode` bound twice, but that's OK.

The second fact allows us to bound only the topmost type of the field, even if this type is in turn generic:

```rust
#[derive(Encode, Decode)]
struct Struct<T: Trait> {
	field1: Vec<T::Type1>,
	field2: Option<(T::Type1, T::Type2)>,
}
```

In this situation we add `Vec<T::Type1>: Encode` and `Option<(T::Type1, T::Type2)>: Encode` bounds, but Rust is powerful enough to understand that there exists an `impl Encode for Vec<T> where T: Encode`, so this would be effectively equal to `T::Type1: Encode`. The second field processed in the same way, but the reasoning chain would be one link longer.

P.S.: The same applies to `Decode` as well.