### PR TITLE
decode returns Result instead of Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-codec-derive = { path = "derive", version = "3.1", default-features = fal
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
-parity-codec-derive = { path = "derive", version = "3.1", default-features = false }
+parity-codec-derive = { path = "derive", version = "3.1" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-codec-derive = { path = "derive", version = "3.1", default-features = fal
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
-parity-codec-derive = { path = "derive", version = "3.1" }
+parity-codec-derive = { path = "derive", version = "3.1", default-features = false }
 
 [features]
 default = ["std"]

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -66,7 +66,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 				}
 			}
 
-			}
+		},
 		Data::Union(_) => Error::new(Span::call_site(), "Union types are not supported.").to_compile_error(),
 	}
 }

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -62,7 +62,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 			quote! {
 				match #input.read_byte()? {
 					#( #recurse )*
-					x => Err(_parity_codec::Error::new("No such variant in enum ".to_string() + &x.to_string())),
+					x => Err(_parity_codec::Error::new("No such variant in enum")),
 				}
 			}
 
@@ -87,9 +87,9 @@ fn create_decode_expr(field: &Field, name: &proc_macro2::TokenStream, input: &To
 		quote_spanned! { field.span() =>
 			{
 				let res = <<#field_type as _parity_codec::HasCompact>::Type as _parity_codec::Decode>::decode(#input);
-				let fname = stringify!(#name).replace(" ", "");
+				let msg = stringify!(Error decoding field #name);
 				match res {
-					Err(e) => return Err(_parity_codec::Error::new("Error decoding field ".to_string() + &fname + ": " + &e.0)),
+					Err(_) => return Err(_parity_codec::Error::new(msg)),
 					Ok(a) => a.into(),
 				}
 			}
@@ -98,9 +98,9 @@ fn create_decode_expr(field: &Field, name: &proc_macro2::TokenStream, input: &To
 		quote_spanned! { field.span() =>
 			{
 				let res = <#encoded_as as _parity_codec::Decode>::decode(#input);
-				let fname = stringify!(#name).replace(" ", "");
+				let msg = stringify!(Error decoding field #name);
 				match res {
-					Err(e) => return Err(_parity_codec::Error::new("Error decoding field ".to_string() + &fname + ": " + &e.0)),
+					Err(_) => return Err(_parity_codec::Error::new(msg)),
 					Ok(a) => a.into(),
 				}
 			}
@@ -109,9 +109,9 @@ fn create_decode_expr(field: &Field, name: &proc_macro2::TokenStream, input: &To
 		quote_spanned! { field.span() =>
 			{
 				let res = _parity_codec::Decode::decode(#input);
-				let fname = stringify!(#name).replace(" ", "");
+				let msg = stringify!(Error decoding field #name);
 				match res {
-					Err(e) => return Err(_parity_codec::Error::new("Error decoding field ".to_string() + &fname + ": " + &e.0)),
+					Err(_) => return Err(_parity_codec::Error::new(msg)),
 					Ok(a) => a,
 				}
 			}

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -63,7 +63,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 			quote! {
 				match #input.read_byte()? {
 					#( #recurse )*
-					x => Err(_parity_codec::Error::from(#err_msg)),
+					x => Err(#err_msg.into()),
 				}
 			}
 
@@ -83,10 +83,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 		).to_compile_error();
 	}
 
-	#[cfg(feature = "std")]
 	let err_msg = format!("Error decoding field {}", name);
-	#[cfg(not(feature = "std"))]
-	let err_msg = { &name[..0] };
 
 	if compact {
 		let field_type = &field.ty;
@@ -94,7 +91,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 			{
 				let res = <<#field_type as _parity_codec::HasCompact>::Type as _parity_codec::Decode>::decode(#input);
 				match res {
-					Err(_) => return Err(_parity_codec::Error::from(#err_msg)),
+					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a.into(),
 				}
 			}
@@ -104,7 +101,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 			{
 				let res = <#encoded_as as _parity_codec::Decode>::decode(#input);
 				match res {
-					Err(_) => return Err(_parity_codec::Error::from(#err_msg)),
+					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a.into(),
 				}
 			}
@@ -114,7 +111,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 			{
 				let res = _parity_codec::Decode::decode(#input);
 				match res {
-					Err(_) => return Err(_parity_codec::Error::from(#err_msg)),
+					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a,
 				}
 			}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,6 +14,7 @@
 
 //! Derives serialization and deserialization codec for complex structs for simple marshalling.
 
+#![recursion_limit = "128"]
 extern crate proc_macro;
 use proc_macro2;
 
@@ -125,7 +126,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 
 	let impl_block = quote! {
 		impl #impl_generics _parity_codec::Decode for #name #ty_generics #where_clause {
-			fn decode<DecIn: _parity_codec::Input>(#input_: &mut DecIn) -> Option<Self> {
+			fn decode<DecIn: _parity_codec::Input>(#input_: &mut DecIn) -> Result<Self, _parity_codec::Error> {
 				#decoding
 			}
 		}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -95,7 +95,7 @@ pub trait Input {
 impl<'a> Input for &'a [u8] {
 	fn read(&mut self, into: &mut [u8]) -> Result<usize, Error> {
 		if into.len() > self.len() {
-			return Err(Error::from(""));
+			return Err("".into());
 		}
 		let len = ::core::cmp::min(into.len(), self.len());
 		into[..len].copy_from_slice(&self[..len]);
@@ -107,7 +107,7 @@ impl<'a> Input for &'a [u8] {
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error {
 	fn from(_err: std::io::Error) -> Self {
-		Error::from("io error")
+		"io error".into()
 	}
 }
 
@@ -536,10 +536,10 @@ impl Decode for Compact<u8> {
 				if x < 256 {
 					x as u8
 				} else {
-					return Err(Error::from("out of range decoding Compact<u8>"));
+					return Err("out of range decoding Compact<u8>".into());
 				}
 			}
-			_ => return Err(Error::from("unexpected prefix decoding Compact<u8>")),
+			_ => return Err("unexpected prefix decoding Compact<u8>".into()),
 		}))
 	}
 }
@@ -555,10 +555,10 @@ impl Decode for Compact<u16> {
 				if x < 65536 {
 					x as u16
 				} else {
-					return Err(Error::from("out of range decoding Compact<u16>"));
+					return Err("out of range decoding Compact<u16>".into());
 				}
 			}
-			_ => return Err(Error::from("unexpected prefix decoding Compact<u16>")),
+			_ => return Err("unexpected prefix decoding Compact<u16>".into()),
 		}))
 	}
 }
@@ -576,7 +576,7 @@ impl Decode for Compact<u32> {
 					u32::decode(input)?
 				} else {
 					// Out of range for a 32-bit quantity.
-					return Err(Error::from("out of range decoding Compact<u32>"));
+					return Err("out of range decoding Compact<u32>".into());
 				}
 			}
 		}))
@@ -593,7 +593,7 @@ impl Decode for Compact<u64> {
 			3|_ => match (prefix >> 2) + 4 {
 				4 => u32::decode(input)? as u64,
 				8 => u64::decode(input)?,
-				x if x > 8 => return Err(Error::from("unexpected prefix decoding Compact<u64>")),
+				x if x > 8 => return Err("unexpected prefix decoding Compact<u64>".into()),
 				bytes_needed => {
 					let mut res = 0;
 					for i in 0..bytes_needed {
@@ -617,7 +617,7 @@ impl Decode for Compact<u128> {
 				4 => u32::decode(input)? as u128,
 				8 => u64::decode(input)? as u128,
 				16 => u128::decode(input)?,
-				x if x > 16 => return Err(Error::from("unexpected prefix decoding Compact<u128>")),
+				x if x > 16 => return Err("unexpected prefix decoding Compact<u128>".into()),
 				bytes_needed => {
 					let mut res = 0;
 					for i in 0..bytes_needed {
@@ -652,7 +652,7 @@ impl<T: Decode, E: Decode> Decode for Result<T, E> {
 		match input.read_byte()? {
 			0 => Ok(Ok(T::decode(input)?)),
 			1 => Ok(Err(E::decode(input)?)),
-			_ => Err(Error::from("unexpected first byte decoding Result")),
+			_ => Err("unexpected first byte decoding Result".into()),
 		}
 	}
 }
@@ -683,7 +683,7 @@ impl Decode for OptionBool {
 			0 => Ok(OptionBool(None)),
 			1 => Ok(OptionBool(Some(true))),
 			2 => Ok(OptionBool(Some(false))),
-			_ => Err(Error::from("unexpected first byte decoding OptionBool")),
+			_ => Err("unexpected first byte decoding OptionBool".into()),
 		}
 	}
 }
@@ -705,7 +705,7 @@ impl<T: Decode> Decode for Option<T> {
 		match input.read_byte()? {
 			0 => Ok(None),
 			1 => Ok(Some(T::decode(input)?)),
-			_ => Err(Error::from("unexpecded first byte decoding Option")),
+			_ => Err("unexpecded first byte decoding Option".into()),
 		}
 	}
 }
@@ -730,7 +730,7 @@ macro_rules! impl_array {
 
 				match i {
 					Ok(a) => Ok(a),
-					Err(_) => Err(Error::from("failed to get inner array from ArrayVec")),
+					Err(_) => Err("failed to get inner array from ArrayVec".into()),
 				}
 			}
 		}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -32,10 +32,12 @@ use core::marker::PhantomData;
 use std::fmt;
 
 #[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq)]
 #[cfg(feature = "std")]
 pub struct Error(&'static str);
 
 #[cfg(not(feature = "std"))]
+#[derive(PartialEq)]
 pub struct Error;
 
 impl Error {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -32,16 +32,21 @@ use core::marker::PhantomData;
 use std::fmt;
 
 #[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq)]
+#[cfg(feature = "std")]
 pub struct Error(&'static str);
 
-impl Error {
-	pub fn new(s: &'static str) -> Error {
-		Error(s)
-	}
+#[cfg(not(feature = "std"))]
+pub struct Error;
 
+impl Error {
+	#[cfg(feature = "std")]
 	pub fn what(&self) -> &'static str {
 		self.0
+	}
+
+	#[cfg(not(feature = "std"))]
+	pub fn what(&self) -> &'static str {
+		""
 	}
 }
 
@@ -59,10 +64,15 @@ impl std::error::Error for Error {
 	}
 }
 
-#[cfg(feature = "std")]
 impl From<&'static str> for Error {
+	#[cfg(feature = "std")]
 	fn from(s: &'static str) -> Error {
 		return Error(s)
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn from(_s: &'static str) -> Error {
+		return Error
 	}
 }
 
@@ -83,7 +93,7 @@ pub trait Input {
 impl<'a> Input for &'a [u8] {
 	fn read(&mut self, into: &mut [u8]) -> Result<usize, Error> {
 		if into.len() > self.len() {
-			return Err(Error("failed to fill whole buffer"));
+			return Err(Error::from(""));
 		}
 		let len = ::core::cmp::min(into.len(), self.len());
 		into[..len].copy_from_slice(&self[..len]);
@@ -95,7 +105,7 @@ impl<'a> Input for &'a [u8] {
 #[cfg(feature = "std")]
 impl From<std::io::Error> for Error {
 	fn from(_err: std::io::Error) -> Self {
-		Error::new("io error ")
+		Error::from("io error")
 	}
 }
 
@@ -524,10 +534,10 @@ impl Decode for Compact<u8> {
 				if x < 256 {
 					x as u8
 				} else {
-					return Err(Error("out of range decoding Compact<u8>"));
+					return Err(Error::from("out of range decoding Compact<u8>"));
 				}
 			}
-			_ => return Err(Error("unexpected prefix decoding Compact<u8>")),
+			_ => return Err(Error::from("unexpected prefix decoding Compact<u8>")),
 		}))
 	}
 }
@@ -543,10 +553,10 @@ impl Decode for Compact<u16> {
 				if x < 65536 {
 					x as u16
 				} else {
-					return Err(Error("out of range decoding Compact<u16>"));
+					return Err(Error::from("out of range decoding Compact<u16>"));
 				}
 			}
-			_ => return Err(Error("unexpected prefix decoding Compact<u16>")),
+			_ => return Err(Error::from("unexpected prefix decoding Compact<u16>")),
 		}))
 	}
 }
@@ -564,7 +574,7 @@ impl Decode for Compact<u32> {
 					u32::decode(input)?
 				} else {
 					// Out of range for a 32-bit quantity.
-					return Err(Error("out of range decoding Compact<u32>"));
+					return Err(Error::from("out of range decoding Compact<u32>"));
 				}
 			}
 		}))
@@ -581,7 +591,7 @@ impl Decode for Compact<u64> {
 			3|_ => match (prefix >> 2) + 4 {
 				4 => u32::decode(input)? as u64,
 				8 => u64::decode(input)?,
-				x if x > 8 => return Err(Error("unexpected prefix decoding Compact<u64>")),
+				x if x > 8 => return Err(Error::from("unexpected prefix decoding Compact<u64>")),
 				bytes_needed => {
 					let mut res = 0;
 					for i in 0..bytes_needed {
@@ -605,7 +615,7 @@ impl Decode for Compact<u128> {
 				4 => u32::decode(input)? as u128,
 				8 => u64::decode(input)? as u128,
 				16 => u128::decode(input)?,
-				x if x > 16 => return Err(Error("unexpected prefix decoding Compact<u128>")),
+				x if x > 16 => return Err(Error::from("unexpected prefix decoding Compact<u128>")),
 				bytes_needed => {
 					let mut res = 0;
 					for i in 0..bytes_needed {
@@ -640,7 +650,7 @@ impl<T: Decode, E: Decode> Decode for Result<T, E> {
 		match input.read_byte()? {
 			0 => Ok(Ok(T::decode(input)?)),
 			1 => Ok(Err(E::decode(input)?)),
-			_ => Err(Error("unexpected first byte decoding Result")),
+			_ => Err(Error::from("unexpected first byte decoding Result")),
 		}
 	}
 }
@@ -671,7 +681,7 @@ impl Decode for OptionBool {
 			0 => Ok(OptionBool(None)),
 			1 => Ok(OptionBool(Some(true))),
 			2 => Ok(OptionBool(Some(false))),
-			_ => Err(Error("unexpected first byte decoding OptionBool".into())),
+			_ => Err(Error::from("unexpected first byte decoding OptionBool")),
 		}
 	}
 }
@@ -693,7 +703,7 @@ impl<T: Decode> Decode for Option<T> {
 		match input.read_byte()? {
 			0 => Ok(None),
 			1 => Ok(Some(T::decode(input)?)),
-			_ => Err(Error("unexpecded first byte decoding Option")),
+			_ => Err(Error::from("unexpecded first byte decoding Option")),
 		}
 	}
 }
@@ -718,7 +728,7 @@ macro_rules! impl_array {
 
 				match i {
 					Ok(a) => Ok(a),
-					Err(_) => Err(Error("failed to get inner array from ArrayVec")),
+					Err(_) => Err(Error::from("failed to get inner array from ArrayVec")),
 				}
 			}
 		}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -59,6 +59,13 @@ impl std::error::Error for Error {
 	}
 }
 
+#[cfg(feature = "std")]
+impl From<&'static str> for Error {
+	fn from(s: &'static str) -> Error {
+		return Error(s)
+	}
+}
+
 /// Trait that allows reading of data into a slice.
 pub trait Input {
 	/// Read into the provided input slice. Returns the number of bytes read.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -28,6 +28,9 @@ use core::{mem, slice};
 use arrayvec::ArrayVec;
 use core::marker::PhantomData;
 
+#[cfg(feature = "std")]
+use std::fmt;
+
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(PartialEq)]
 pub struct Error(&'static str);
@@ -42,10 +45,17 @@ impl Error {
 	}
 }
 
-#[cfg(any(feature = "std", feature = "full"))]
-impl ToString for Error {
-	fn to_string(&self) -> String {
-		self.0.to_string()
+#[cfg(feature = "std")]
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+	fn description(&self) -> &str {
+		self.0
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,6 @@ mod codec;
 mod joiner;
 mod keyedvec;
 
-pub use self::codec::{Input, Output, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs};
+pub use self::codec::{Input, Output, Error, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -124,13 +124,13 @@ fn should_work_for_simple_enum() {
 	});
 
 	let mut da: &[u8] = b"\x0f";
-	assert_eq!(EnumType::decode(&mut da), Some(a));
+	assert_eq!(EnumType::decode(&mut da).ok(), Some(a));
 	let mut db: &[u8] = b"\x01\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(EnumType::decode(&mut db), Some(b));
+	assert_eq!(EnumType::decode(&mut db).ok(), Some(b));
 	let mut dc: &[u8] = b"\x02\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(EnumType::decode(&mut dc), Some(c));
+	assert_eq!(EnumType::decode(&mut dc).ok(), Some(c));
 	let mut dz: &[u8] = &[0];
-	assert_eq!(EnumType::decode(&mut dz), None);
+	assert_eq!(EnumType::decode(&mut dz).ok(), None);
 }
 
 #[test]
@@ -146,13 +146,13 @@ fn should_work_for_enum_with_discriminant() {
 	});
 
 	let mut da: &[u8] = &[1];
-	assert_eq!(EnumWithDiscriminant::decode(&mut da), Some(EnumWithDiscriminant::A));
+	assert_eq!(EnumWithDiscriminant::decode(&mut da), Ok(EnumWithDiscriminant::A));
 	let mut db: &[u8] = &[15];
-	assert_eq!(EnumWithDiscriminant::decode(&mut db), Some(EnumWithDiscriminant::B));
+	assert_eq!(EnumWithDiscriminant::decode(&mut db), Ok(EnumWithDiscriminant::B));
 	let mut dc: &[u8] = &[255];
-	assert_eq!(EnumWithDiscriminant::decode(&mut dc), Some(EnumWithDiscriminant::C));
+	assert_eq!(EnumWithDiscriminant::decode(&mut dc), Ok(EnumWithDiscriminant::C));
 	let mut dz: &[u8] = &[2];
-	assert_eq!(EnumWithDiscriminant::decode(&mut dz), None);
+	assert_eq!(EnumWithDiscriminant::decode(&mut dz).ok(), None);
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn should_derive_decode() {
 
 	let v = TestType::decode(&mut &*slice);
 
-	assert_eq!(v, Some(TestType::new(15, 9, b"Hello world".to_vec())));
+	assert_eq!(v, Ok(TestType::new(15, 9, b"Hello world".to_vec())));
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn should_work_for_unit() {
 	});
 
 	let mut a: &[u8] = &[];
-	assert_eq!(Unit::decode(&mut a), Some(Unit));
+	assert_eq!(Unit::decode(&mut a), Ok(Unit));
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn should_work_for_indexed() {
 	});
 
 	let mut v: &[u8] = b"\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(Indexed::decode(&mut v), Some(Indexed(1, 2)));
+	assert_eq!(Indexed::decode(&mut v), Ok(Indexed(1, 2)));
 }
 
 const U64_TEST_COMPACT_VALUES: &[(u64, usize)] = &[

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -218,6 +218,20 @@ fn correct_error_for_enumtype() {
 	EnumType::decode(&mut wrong).unwrap();
 }
 
+#[test]
+#[should_panic(expected = "Error decoding field Struct.a")]
+fn correct_error_for_named_struct_1() {
+	let mut wrong: &[u8] = b"\x01";
+	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Error decoding field Struct.b")]
+fn correct_error_for_named_struct_2() {
+	let mut wrong: &[u8] = b"\0\0\0\0\x01";
+	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
+}
+
 const U64_TEST_COMPACT_VALUES: &[(u64, usize)] = &[
 	(0u64, 1usize), (63, 1), (64, 2), (16383, 2),
 	(16384, 4), (1073741823, 4),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -197,6 +197,27 @@ fn should_work_for_indexed() {
 	assert_eq!(Indexed::decode(&mut v), Ok(Indexed(1, 2)));
 }
 
+#[test]
+#[should_panic(expected = "Error decoding field Indexed.0")]
+fn correct_error_for_indexed_0() {
+	let mut wrong: &[u8] = b"\x08";
+	Indexed::decode(&mut wrong).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Error decoding field Indexed.1")]
+fn correct_error_for_indexed_1() {
+	let mut wrong: &[u8] = b"\0\0\0\0\x01";
+	Indexed::decode(&mut wrong).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Error decoding field EnumType :: B.0")]
+fn correct_error_for_enumtype() {
+	let mut wrong: &[u8] = b"\x01";
+	EnumType::decode(&mut wrong).unwrap();
+}
+
 const U64_TEST_COMPACT_VALUES: &[(u64, usize)] = &[
 	(0u64, 1usize), (63, 1), (64, 2), (16383, 2),
 	(16384, 4), (1073741823, 4),


### PR DESCRIPTION
A very WIP attempt to fix  #33

The main idea is to propagate infomative errors from ```Decode::decode```, for instance the following code:

```rust
extern crate parity_codec;
extern crate parity_codec_derive;

use parity_codec::Decode;
use parity_codec_derive::{Encode, Decode};

#[derive(Encode, Decode, Debug)]
struct Test2(u32);

#[derive(Encode, Decode, Debug)]
struct Test{
        a: u32,
        c: Test2,
}

#[derive(Encode, Decode, Debug)]
enum TestEnum {
        Var1,
        Var2(u32),
}

fn main() {
        let mut wrong: &[u8] = b"\x0f";

        match Test::decode(&mut wrong) {
                Ok(_) => (),
                Err(a) => println!("error {}", a),
        }
        match Test2::decode(&mut wrong) {
                Ok(_) => (),
                Err(a) => println!("error {}", a),
        }
        match TestEnum::decode(&mut wrong) {
                Err(a) => println!("error {}", a),
                _ => (),
        }
}

```

yeilds the following messages on

```
error Error decoding field Test.a
error Error decoding field Test2.0
error No such variant in enum TestEnum

```