### PR TITLE
new version of derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,14 +16,14 @@ name = "parity-codec"
 version = "3.2.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.1.0",
+ "parity-codec-derive 3.2.0",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parity-codec-derive"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-codec-derive"
 description = "Serialization and deserialization derive macro for Parity Codec"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
pr to the branch parity-codec-v3.2 the change in derive, then I'll tag and publish once merged.

Or we can wait for a full 4.0 release I don't have opinion at all