### PR TITLE
Support BitVec, BitBox and BitSlice

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ cache:
 test:rust:stable:
   stage:                           test
   script:
-    - time cargo test --verbose --all
+    - time cargo test --verbose --all --features bit-vec
   only:
     - triggers
     - tags
@@ -37,7 +37,7 @@ test:rust:stable:
 bench:rust:nightly:
   stage:                           test
   script:
-    - time cargo +nightly bench
+    - time cargo +nightly bench --features bit-vec
   only:
     - triggers
     - tags
@@ -53,7 +53,7 @@ bench:rust:nightly:
 build:linux:ubuntu:amd64:
   stage:                           build
   script:
-    - cargo build --verbose --release
+    - cargo build --verbose --release --features bit-vec
   only:
     - master
     - tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byte-slice-cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +29,7 @@ version = "3.3.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.3.0",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -104,6 +110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c28d4291b516ccfbb897d45de3c468c135e6af7c4f1f1aacfaae0a5bc2e6ea2c"
+"checksum byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d6eec63fe0fb4f9f0f8011d32ab1586c123f1248c930a35237ff4ef08beaf1"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c6cf4e5b00300d151dfffae39f529dfa5188f42eeb14201229aa420d6aad10c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +23,7 @@ name = "parity-codec"
 version = "3.3.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.3.0",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,6 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c28d4291b516ccfbb897d45de3c468c135e6af7c4f1f1aacfaae0a5bc2e6ea2c"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c6cf4e5b00300d151dfffae39f529dfa5188f42eeb14201229aa420d6aad10c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 arrayvec = { version = "0.4", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0", optional = true }
 parity-codec-derive = { path = "derive", version = "3.3", default-features = false, optional = true }
+bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
@@ -20,7 +21,8 @@ parity-codec-derive = { path = "derive", version = "3.3", default-features = fal
 [features]
 default = ["std"]
 derive = ["parity-codec-derive"]
-std = ["serde"]
+std = ["serde", "bitvec/std"]
+bit-vec = ["bitvec"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ arrayvec = { version = "0.4", default-features = false, features = ["array-sizes
 serde = { version = "1.0", optional = true }
 parity-codec-derive = { path = "derive", version = "3.3", default-features = false, optional = true }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
+byte-slice-cast = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
@@ -22,7 +23,7 @@ parity-codec-derive = { path = "derive", version = "3.3", default-features = fal
 default = ["std"]
 derive = ["parity-codec-derive"]
 std = ["serde", "bitvec/std"]
-bit-vec = ["bitvec"]
+bit-vec = ["bitvec", "byte-slice-cast"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -24,8 +24,8 @@ use crate::codec::{Encode, Decode, Input, Output, Compact, Error};
 impl From<FromByteSliceError> for Error {
 	fn from(e: FromByteSliceError) -> Error {
 		match e {
-			FromByteSliceError::AlignmentMismatch{..} => "failed to cast from byte slice: alignment mismatch".into(),
-			FromByteSliceError::LengthMismatch{..} => "failed to cast from byte slice: length mismatch".into(),
+			FromByteSliceError::AlignmentMismatch {..} => "failed to cast from byte slice: alignment mismatch".into(),
+			FromByteSliceError::LengthMismatch {..} => "failed to cast from byte slice: length mismatch".into(),
 		}
 	}
 }

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -22,8 +22,11 @@ use byte_slice_cast::{AsByteSlice, ToByteSlice, FromByteSlice, Error as FromByte
 use crate::codec::{Encode, Decode, Input, Output, Compact, Error};
 
 impl From<FromByteSliceError> for Error {
-	fn from(_: FromByteSliceError) -> Error {
-		"failed to cast from byte slice".into()
+	fn from(e: FromByteSliceError) -> Error {
+		match e {
+			FromByteSliceError::AlignmentMismatch{..} => "failed to cast from byte slice: alignment mismatch".into(),
+			FromByteSliceError::LengthMismatch{..} => "failed to cast from byte slice: length mismatch".into(),
+		}
 	}
 }
 

--- a/src/bitvec.rs
+++ b/src/bitvec.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `BitVec` specific serialization.
+
+use bitvec::vec::BitVec;
+
+use std::mem;
+
+use crate::codec::{Encode, Decode, Input, Output, Compact, Error};
+
+impl Encode for BitVec {
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		let a1 = vec![1u16, 2, 3];
+		//dest.write(a1.as_slice());
+
+
+
+
+
+		let len = self.len();
+		assert!(len <= u32::max_value() as usize, "Attempted to serialize a collection with too many elements.");
+		Compact(len as u32).encode_to(dest);
+		dest.write(self.as_slice());
+	}
+}
+
+impl Decode for BitVec {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
+			let element_size = (mem::size_of::<u8>() * 8) as f64;
+			let len_in_bytes = (len as f64 / element_size).ceil() as usize;
+			let mut array = Vec::<u8>::new();
+			for _ in 0..len_in_bytes {
+				//array.push(Compact::<u8>::decode(input)?.0);
+				array.push(input.read_byte()?);
+			}
+			let mut result = Self::from_slice(array.as_slice());
+			assert!(len <= result.len() as u32);
+			unsafe { result.set_len(len as usize); }
+			Ok(result)
+
+
+//			// TODO:
+//			let array = match array.into_inner() {
+//				Ok(a) => a,
+//				Err(_) => Err("failed to get inner array from ArrayVec".into()),
+//			};
+
+
+
+			///////////////////////////////////////////////////////////////////////////////////////////////
+			//let mut r = ArrayVec::new();
+			//for _ in 0..$n {
+//				r.push(T::decode(input)?);
+			//}
+//			let i = r.into_inner();
+//
+//			/match i {
+//				Ok(a) => Ok(a),
+//				Err(_) => Err("failed to get inner array from ArrayVec".into()),
+//			}
+			///////////////////////////////////////////////////////////////////////////////////////////////
+
+
+
+//			let len = len as usize;
+//			let mut v = Self::from_vec(Vec::<u8>::decode(input)?);
+//			assert!(len <= v.len());
+//			unsafe { v.set_len(len); }
+//			Ok(v)
+		})
+	}
+}
+
+// TODO: FIXME: bit slice, bitbox, etc.
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn bitvec_u8() {
+		use bitvec::bitvec;
+
+		let vecs = [
+			BitVec::new(),
+			bitvec![0],
+			bitvec![1],
+			bitvec![0, 0],
+			bitvec![1, 0],
+			bitvec![0, 1],
+			bitvec![1, 1],
+			bitvec![0, 1, 0],
+			bitvec![0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1],
+		];
+
+		for v in &vecs {
+			let encoded = v.encode();
+			assert_eq!(*v, BitVec::decode(&mut &encoded[..]).unwrap());
+		}
+	}
+}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -32,6 +32,9 @@ use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::fmt;
 
+#[cfg(feature = "bit-vec")]
+use bitvec::vec::BitVec;
+
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(PartialEq)]
 #[cfg(feature = "std")]
@@ -1227,6 +1230,29 @@ impl Decode for () {
 	}
 }
 
+#[cfg(feature = "bit-vec")]
+impl Encode for BitVec {
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		let len = self.len();
+		assert!(len <= u32::max_value() as usize, "Attempted to serialize a collection with too many elements.");
+		Compact(len as u32).encode_to(dest);
+		self.as_slice().encode_to(dest)
+	}
+}
+
+#[cfg(feature = "bit-vec")]
+impl Decode for BitVec {
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
+			let len = len as usize;
+			let mut v = Self::from_vec(Vec::<u8>::decode(input)?);
+			assert!(len <= v.len());
+			unsafe { v.set_len(len); }
+			Ok(v)
+		})
+	}
+}
+
 macro_rules! tuple_impl {
 	($one:ident,) => {
 		impl<$one: Encode> Encode for ($one,) {
@@ -1879,8 +1905,6 @@ mod tests {
 		}
 	}
 
-
-
 	#[test]
 	fn should_avoid_overlapping_definition() {
 		check_bound!(
@@ -1899,6 +1923,29 @@ mod tests {
 		}
 		for i in 8..=16 {
 			check_bound_high!(i, [(u128, U128_OUT_OF_RANGE)]);
+		}
+	}
+
+	#[cfg(feature = "bit-vec")]
+	#[test]
+	fn bitvec_test() {
+		use bitvec::bitvec;
+
+		let vecs = [
+			BitVec::new(),
+			bitvec![0],
+			bitvec![1],
+			bitvec![0, 0],
+			bitvec![1, 0],
+			bitvec![0, 1],
+			bitvec![1, 1],
+			bitvec![0, 1, 0],
+			bitvec![0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1],
+		];
+
+		for v in &vecs {
+			let encoded = v.encode();
+			assert_eq!(*v, BitVec::decode(&mut &encoded[..]).unwrap());
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod alloc {
 mod codec;
 mod joiner;
 mod keyedvec;
+#[cfg(feature = "bit-vec")]
+mod bitvec;
 
 pub use self::codec::{Input, Output, Error, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs, EncodeAppend};
 pub use self::joiner::Joiner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ mod codec;
 mod joiner;
 mod keyedvec;
 #[cfg(feature = "bit-vec")]
-mod bitvec;
+mod bit_vec;
 
 pub use self::codec::{Input, Output, Error, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs, EncodeAppend};
 pub use self::joiner::Joiner;


### PR DESCRIPTION
Naive implementation to start with. I suppose we also need `BitBox` and `BitSlice` support. Not sure if flexibility to use different [cursor](https://docs.rs/bitvec/0.11.1/bitvec/cursor/index.html) and inner types is needed.

Needed for https://github.com/paritytech/polkadot/issues/254.