### PR TITLE
Introduce U8 wrapper encode usable with encoded_as

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1428,7 +1428,7 @@ impl From<U8> for u8 {
 }
 
 impl Decode for U8 {
-	fn decode<I: Input>(_value: &mut I) -> Option<Self> {
+	fn decode<I: Input>(_value: &mut I) -> Result<Self, Error> {
 		unimplemented!();
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1419,6 +1419,37 @@ impl_non_endians!(
 	[u8; 112], [u8; 128], bool
 );
 
+pub struct U8(u8);
+
+impl From<U8> for u8 {
+	fn from(x: U8) -> Self {
+		x.0
+	}
+}
+
+impl Decode for U8 {
+	fn decode<I: Input>(_value: &mut I) -> Option<Self> {
+		unimplemented!();
+	}
+}
+
+pub struct RefU8<'a>(&'a u8);
+
+impl<'a> From<&'a u8> for RefU8<'a> {
+	fn from(x: &'a u8) -> Self {
+		RefU8(x)
+	}
+}
+
+impl<'a> Encode for RefU8<'a> {
+	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, _f: F) -> R {
+		unimplemented!();
+	}
+}
+
+impl<'a> EncodeAsRef<'a, u8> for U8 {
+	type RefType = RefU8<'a>;
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ mod codec;
 mod joiner;
 mod keyedvec;
 
-pub use self::codec::{Input, Output, Error, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs, EncodeAppend};
+pub use self::codec::{
+	Input, Output, Error, Encode, Decode, Codec, Compact, HasCompact, EncodeAsRef, CompactAs,
+	EncodeAppend, U8
+};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -34,6 +34,12 @@ struct Struct<A, B, C> {
 }
 
 #[derive(Debug, PartialEq, Encode, Decode)]
+struct A {
+	#[codec(encoded_as = "parity_codec::U8")]
+	pub i: u8,
+}
+
+#[derive(Debug, PartialEq, Encode, Decode)]
 struct StructWithPhantom {
 	pub a: u32,
 	pub b: u64,


### PR DESCRIPTION
this is a wip implementation, that can be finished if ppl think it is interesting.

at the end user will be able to use it as such
```
#[derive(Debug, PartialEq, Encode, Decode)]
struct A {
	#[codec(encoded_as = "U8")]
	pub i: u8,
}
```