### PR TITLE
Release 4.0.0 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-codec"
-version = "3.5.2"
+version = "4.0.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-codec"
 description = "Lightweight, efficient, binary serialization and deserialization codec"
-version = "3.5.2"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-codec"


### PR DESCRIPTION
Major version must be increased because `Encode`/`Decode` no longer implemented for `isize` and `usize`.