### PR TITLE
Rename to `parity-scale-codec` and revert version to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,25 +24,25 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "parity-codec-derive"
-version = "3.3.0"
-dependencies = [
- "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "1.0.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0",
+ "parity-scale-codec-derive 1.0.0",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "1.0.0"
+dependencies = [
+ "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,18 +24,6 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "parity-codec"
-version = "3.3.0"
-dependencies = [
- "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec-derive 3.3.0",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parity-codec-derive"
 version = "3.3.0"
 dependencies = [
@@ -43,6 +31,18 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.0.0"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec-derive 3.3.0",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "parity-codec"
-description = "Lightweight, efficient, binary serialization and deserialization codec"
-version = "3.3.0"
+name = "parity-scale-codec"
+description = "SCALE - Simple Concatenating Aggregated Little Endians"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "SCALE - Simple Concatenating Aggregated Little Endians"
 version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
-repository = "https://github.com/paritytech/parity-codec"
+repository = "https://github.com/paritytech/parity-scale-codec"
 categories = ["encoding"]
 edition = "2018"
 
@@ -36,14 +36,8 @@ bit-vec = ["bitvec", "byte-slice-cast"]
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #
 # Provides implementations for more data structures than just Vec and Box.
-# Concretely it will provide parity-codec implementations for many types
+# Concretely it will provide parity-scale-codec implementations for many types
 # that can be found in std and/or alloc (nightly).
-#
-# This feature was mainly introduced after it became clear that pDSL requires
-# it for the sake of usability of its users.
-#
-# * For rational about this please visit:
-# https://github.com/paritytech/parity-codec/pull/27#issuecomment-453031914
 full = []
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.4", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0", optional = true }
-parity-codec-derive = { path = "derive", version = "3.3", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false, optional = true }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
-parity-codec-derive = { path = "derive", version = "3.3", default-features = false }
+parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false }
 
 [features]
 default = ["std"]
-derive = ["parity-codec-derive"]
+derive = ["parity-scale-codec-derive"]
 std = ["serde", "bitvec/std"]
 bit-vec = ["bitvec", "byte-slice-cast"]
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -16,8 +16,8 @@
 
 extern crate test;
 
-use parity_codec::*;
-use parity_codec_derive::{Encode, Decode};
+use parity_scale_codec::*;
+use parity_scale_codec_derive::{Encode, Decode};
 
 #[bench]
 fn array_vec_write_u128(b: &mut test::Bencher) {

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "parity-codec-derive"
-description = "Serialization and deserialization derive macro for Parity Codec"
-version = "3.3.0"
+name = "parity-scale-codec-derive"
+description = "Serialization and deserialization derive macro for Parity SCALE Codec"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -92,7 +92,9 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
 			{
-				let res = <<#field_type as _parity_codec::HasCompact>::Type as _parity_codec::Decode>::decode(#input);
+				let res = <
+					<#field_type as _parity_scale_codec::HasCompact>::Type as _parity_scale_codec::Decode
+				>::decode(#input);
 				match res {
 					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a.into(),
@@ -102,7 +104,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 	} else if let Some(encoded_as) = encoded_as {
 		quote_spanned! { field.span() =>
 			{
-				let res = <#encoded_as as _parity_codec::Decode>::decode(#input);
+				let res = <#encoded_as as _parity_scale_codec::Decode>::decode(#input);
 				match res {
 					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a.into(),
@@ -114,7 +116,7 @@ fn create_decode_expr(field: &Field, name: &String, input: &TokenStream) -> Toke
 	} else {
 		quote_spanned! { field.span() =>
 			{
-				let res = _parity_codec::Decode::decode(#input);
+				let res = _parity_scale_codec::Decode::decode(#input);
 				match res {
 					Err(_) => return Err(#err_msg.into()),
 					Ok(a) => a,

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -53,8 +53,8 @@ fn encode_single_field(
 		let field_type = &field.ty;
 		quote_spanned! {
 			field.span() => {
-				<<#field_type as _parity_codec::HasCompact>::Type as
-					_parity_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
+				<<#field_type as _parity_scale_codec::HasCompact>::Type as
+					_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
 					.using_encoded(#closure)
 			}
 		}
@@ -63,13 +63,13 @@ fn encode_single_field(
 		quote_spanned! {
 			field.span() => {
 				<#encoded_as as
-					_parity_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
+					_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
 					.using_encoded(#closure)
 			}
 		}
 	} else {
 		quote_spanned! { field.span() =>
-			_parity_codec::Encode::using_encoded(&#field_name, #closure)
+			_parity_scale_codec::Encode::using_encoded(&#field_name, #closure)
 		}
 	}
 }
@@ -101,8 +101,8 @@ fn encode_fields<F>(
 			quote_spanned! {
 				f.span() => {
 					#dest.push(
-						&<<#field_type as _parity_codec::HasCompact>::Type as
-							_parity_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
+						&<<#field_type as _parity_scale_codec::HasCompact>::Type as
+							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
 					);
 				}
 			}
@@ -112,7 +112,7 @@ fn encode_fields<F>(
 				f.span() => {
 					#dest.push(
 						&<#encoded_as as
-							_parity_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
+							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
 					);
 				}
 			}
@@ -289,7 +289,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 	};
 
 	quote! {
-		fn encode_to<EncOut: _parity_codec::Output>(&#self_, #dest: &mut EncOut) {
+		fn encode_to<EncOut: _parity_scale_codec::Output>(&#self_, #dest: &mut EncOut) {
 			#encoding
 		}
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -36,16 +36,16 @@ mod encode;
 mod utils;
 mod trait_bounds;
 
-/// Include the `parity-codec` crate under a known name (`_parity_codec`).
-fn include_parity_codec_crate() -> proc_macro2::TokenStream {
+/// Include the `parity-scale-codec` crate under a known name (`_parity_scale_codec`).
+fn include_parity_scale_codec_crate() -> proc_macro2::TokenStream {
 	// This "hack" is required for the tests.
-	if env::var("CARGO_PKG_NAME").unwrap() == "parity-codec" {
-		quote!( extern crate parity_codec as _parity_codec; )
+	if env::var("CARGO_PKG_NAME").unwrap() == "parity-scale-codec" {
+		quote!( extern crate parity_scale_codec as _parity_scale_codec; )
 	} else {
-		match crate_name("parity-codec") {
+		match crate_name("parity-scale-codec") {
 			Ok(parity_codec_crate) => {
 				let ident = Ident::new(&parity_codec_crate, Span::call_site());
-				quote!( extern crate #ident as _parity_codec; )
+				quote!( extern crate #ident as _parity_scale_codec; )
 			},
 			Err(e) => Error::new(Span::call_site(), &e).to_compile_error(),
 		}
@@ -67,7 +67,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 		&input.ident,
 		&mut input.generics,
 		&input.data,
-		parse_quote!(_parity_codec::Encode),
+		parse_quote!(_parity_scale_codec::Encode),
 		None,
 	) {
 		return e.to_compile_error().into();
@@ -79,7 +79,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 	let encode_impl = encode::quote(&input.data, name);
 
 	let impl_block = quote! {
-		impl #impl_generics _parity_codec::Encode for #name #ty_generics #where_clause {
+		impl #impl_generics _parity_scale_codec::Encode for #name #ty_generics #where_clause {
 			#encode_impl
 		}
 	};
@@ -87,7 +87,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 	let mut new_name = "_IMPL_ENCODE_FOR_".to_string();
 	new_name.push_str(name.to_string().trim_start_matches("r#"));
 	let dummy_const = Ident::new(&new_name, Span::call_site());
-	let parity_codec_crate = include_parity_codec_crate();
+	let parity_codec_crate = include_parity_scale_codec_crate();
 
 	let generated = quote! {
 		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
@@ -118,7 +118,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 		&input.ident,
 		&mut input.generics,
 		&input.data,
-		parse_quote!(_parity_codec::Decode),
+		parse_quote!(_parity_scale_codec::Decode),
 		Some(parse_quote!(Default))
 	) {
 		return e.to_compile_error().into();
@@ -131,8 +131,10 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 	let decoding = decode::quote(&input.data, name, &input_);
 
 	let impl_block = quote! {
-		impl #impl_generics _parity_codec::Decode for #name #ty_generics #where_clause {
-			fn decode<DecIn: _parity_codec::Input>(#input_: &mut DecIn) -> Result<Self, _parity_codec::Error> {
+		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {
+			fn decode<DecIn: _parity_scale_codec::Input>(
+				#input_: &mut DecIn
+			) -> Result<Self, _parity_scale_codec::Error> {
 				#decoding
 			}
 		}
@@ -141,7 +143,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 	let mut new_name = "_IMPL_DECODE_FOR_".to_string();
 	new_name.push_str(name.to_string().trim_start_matches("r#"));
 	let dummy_const = Ident::new(&new_name, Span::call_site());
-	let parity_codec_crate = include_parity_codec_crate();
+	let parity_codec_crate = include_parity_scale_codec_crate();
 
 	let generated = quote! {
 		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -154,7 +154,7 @@ pub fn add(
 				where_clause.predicates.push(parse_quote!(#ty : #codec_bound))
 			});
 
-		let has_compact_bound: syn::Path = parse_quote!(_parity_codec::HasCompact);
+		let has_compact_bound: syn::Path = parse_quote!(_parity_scale_codec::HasCompact);
 		compact_types
 			.into_iter()
 			.for_each(|ty| {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -207,7 +207,7 @@ impl<T: arrayvec::Array<Item=u8>> Output for ArrayVecWrapper<T> {
 	}
 }
 
-/// This enum must not be exported and must only be instantiable by parity-codec.
+/// This enum must not be exported and must only be instantiable by parity-scale-codec.
 /// Because implementation of Encode and Decode for u8 is done in this crate
 /// and there is not other usage.
 pub enum IsU8 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,18 +25,18 @@
 #[macro_use]
 extern crate alloc;
 
-#[cfg(feature = "parity-codec-derive")]
+#[cfg(feature = "parity-scale-codec-derive")]
 #[allow(unused_imports)]
 #[macro_use]
-extern crate parity_codec_derive;
+extern crate parity_codec_scale_derive;
 
 #[cfg(all(feature = "std", test))]
 #[macro_use]
 extern crate serde_derive;
 
-#[cfg(feature = "parity-codec-derive")]
+#[cfg(feature = "parity-scale-codec-derive")]
 #[doc(hidden)]
-pub use parity_codec_derive::*;
+pub use parity_scale_codec_derive::*;
 
 #[cfg(feature = "std")]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ extern crate alloc;
 #[cfg(feature = "parity-scale-codec-derive")]
 #[allow(unused_imports)]
 #[macro_use]
-extern crate parity_codec_scale_derive;
+extern crate parity_scale_codec_derive;
 
 #[cfg(all(feature = "std", test))]
 #[macro_use]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -16,9 +16,9 @@
 extern crate serde_derive;
 
 #[macro_use]
-extern crate parity_codec_derive;
+extern crate parity_scale_codec_derive;
 
-use parity_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs};
+use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Unit;

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,9 +1,7 @@
 #[macro_use]
-extern crate parity_codec_derive;
+extern crate parity_scale_codec_derive;
 
-use parity_codec::{Encode, HasCompact};
-#[cfg(test)]
-use parity_codec::Decode;
+use parity_scale_codec::{Encode, HasCompact, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct S {

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,7 +1,7 @@
 #[macro_use]
-extern crate parity_codec_derive;
+extern crate parity_scale_codec_derive;
 
-use parity_codec::{Encode, Decode};
+use parity_scale_codec::{Encode, Decode};
 
 #[test]
 fn enum_struct_test() {


### PR DESCRIPTION
Fixes: https://github.com/paritytech/parity-codec/issues/80